### PR TITLE
Fix: 修改HTML <lang>属性到zh-CN

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />


### PR DESCRIPTION
### 修复内容
更新 HTML 文件中的 `<lang>` 属性，将值从 `en` 修改为 `zh-CN`，以确保页面的语言设置正确。

### 问题背景
- 当前 `<lang>` 属性值错误，设置为 `en`，导致浏览器和搜索引擎无法正确识别页面语言。
- 相关 Issue: #5 

### 修复说明
- 修改了 `index.html` 文件的 `<html>` 标签：
  - 由 `<html lang="en">` 修改为 `<html lang="zh-CN">`

### 影响范围
此修复只影响页面的语言标记，不涉及功能性改动。